### PR TITLE
Add `extern` so constants aren't re-declared every time the `PayPalMobile.h` file is imported.

### DIFF
--- a/PayPalMobile/PayPalOAuthScopes.h
+++ b/PayPalMobile/PayPalOAuthScopes.h
@@ -11,17 +11,17 @@
 // @see https://developer.paypal.com/docs/integration/direct/identity/attributes/ for more details
 
 /// Authorize charges for future purchases paid for with PayPal.
-NSString *const kPayPalOAuth2ScopeFuturePayments;
+extern NSString *const kPayPalOAuth2ScopeFuturePayments;
 /// Share basic account information.
-NSString *const kPayPalOAuth2ScopeProfile;
+extern NSString *const kPayPalOAuth2ScopeProfile;
 /// Basic Authentication.
-NSString *const kPayPalOAuth2ScopeOpenId;
+extern NSString *const kPayPalOAuth2ScopeOpenId;
 /// Share your personal and account information.
-NSString *const kPayPalOAuth2ScopePayPalAttributes;
+extern NSString *const kPayPalOAuth2ScopePayPalAttributes;
 /// Share your email address.
-NSString *const kPayPalOAuth2ScopeEmail;
+extern NSString *const kPayPalOAuth2ScopeEmail;
 /// Share your account address.
-NSString *const kPayPalOAuth2ScopeAddress;
+extern NSString *const kPayPalOAuth2ScopeAddress;
 /// Share your phone number.
-NSString *const kPayPalOAuth2ScopePhone;
+extern NSString *const kPayPalOAuth2ScopePhone;
 


### PR DESCRIPTION
I created a sample project with the following `Podfile` :

````ruby
target 'EmptyPaypalProject' do
	pod 'PayPal-iOS-SDK'
end
````

I have an empty-ish AppDelegate.m file containing the following:

````objectivec
#import "AppDelegate.h"
#import <PayPal-iOS-SDK/PayPalMobile.h>

- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
    // Override point for customization after application launch.
    return YES;
}

@end
````

When I try to build, I get the following error: 

````
duplicate symbol _kPayPalOAuth2ScopeAddress in:
    /Users/romain/Library/Developer/Xcode/DerivedData/Netlift-cxdsbefdbjhhotahsvxunafzqzci/Build/Intermediates/Netlift.build/Debug-iphonesimulator/Netlift.build/Objects-normal/x86_64/NLAppDelegate.o
    /Users/romain/Projects/netlift-ios/Pods/PayPal-iOS-SDK/PayPalMobile/libPayPalMobile.a(PPAuthNAuthScopes.o)
duplicate symbol _kPayPalOAuth2ScopeEmail in:
    /Users/romain/Library/Developer/Xcode/DerivedData/Netlift-cxdsbefdbjhhotahsvxunafzqzci/Build/Intermediates/Netlift.build/Debug-iphonesimulator/Netlift.build/Objects-normal/x86_64/NLAppDelegate.o
    /Users/romain/Projects/netlift-ios/Pods/PayPal-iOS-SDK/PayPalMobile/libPayPalMobile.a(PPAuthNAuthScopes.o)
duplicate symbol _kPayPalOAuth2ScopeFuturePayments in:
    /Users/romain/Library/Developer/Xcode/DerivedData/Netlift-cxdsbefdbjhhotahsvxunafzqzci/Build/Intermediates/Netlift.build/Debug-iphonesimulator/Netlift.build/Objects-normal/x86_64/NLAppDelegate.o
    /Users/romain/Projects/netlift-ios/Pods/PayPal-iOS-SDK/PayPalMobile/libPayPalMobile.a(PPAuthNAuthScopes.o)
duplicate symbol _kPayPalOAuth2ScopeOpenId in:
    /Users/romain/Library/Developer/Xcode/DerivedData/Netlift-cxdsbefdbjhhotahsvxunafzqzci/Build/Intermediates/Netlift.build/Debug-iphonesimulator/Netlift.build/Objects-normal/x86_64/NLAppDelegate.o
    /Users/romain/Projects/netlift-ios/Pods/PayPal-iOS-SDK/PayPalMobile/libPayPalMobile.a(PPAuthNAuthScopes.o)
duplicate symbol _kPayPalOAuth2ScopePayPalAttributes in:
    /Users/romain/Library/Developer/Xcode/DerivedData/Netlift-cxdsbefdbjhhotahsvxunafzqzci/Build/Intermediates/Netlift.build/Debug-iphonesimulator/Netlift.build/Objects-normal/x86_64/NLAppDelegate.o
    /Users/romain/Projects/netlift-ios/Pods/PayPal-iOS-SDK/PayPalMobile/libPayPalMobile.a(PPAuthNAuthScopes.o)
duplicate symbol _kPayPalOAuth2ScopePhone in:
    /Users/romain/Library/Developer/Xcode/DerivedData/Netlift-cxdsbefdbjhhotahsvxunafzqzci/Build/Intermediates/Netlift.build/Debug-iphonesimulator/Netlift.build/Objects-normal/x86_64/NLAppDelegate.o
    /Users/romain/Projects/netlift-ios/Pods/PayPal-iOS-SDK/PayPalMobile/libPayPalMobile.a(PPAuthNAuthScopes.o)
duplicate symbol _kPayPalOAuth2ScopeProfile in:
    /Users/romain/Library/Developer/Xcode/DerivedData/Netlift-cxdsbefdbjhhotahsvxunafzqzci/Build/Intermediates/Netlift.build/Debug-iphonesimulator/Netlift.build/Objects-normal/x86_64/NLAppDelegate.o
    /Users/romain/Projects/netlift-ios/Pods/PayPal-iOS-SDK/PayPalMobile/libPayPalMobile.a(PPAuthNAuthScopes.o)
ld: 7 duplicate symbols for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
````

This PR fixes this issue. 