### PR TITLE
Fixed typo in swift demo app

### DIFF
--- a/SampleApp-Swift/PayPal-iOS-SDK-Sample-App/MainViewController.swift
+++ b/SampleApp-Swift/PayPal-iOS-SDK-Sample-App/MainViewController.swift
@@ -144,7 +144,7 @@ class MainViewController: UIViewController, PayPalPaymentDelegate, PayPalFutureP
   
   
   func payPalFuturePaymentDidCancel(futurePaymentViewController: PayPalFuturePaymentViewController!) {
-    println("PayPal Future Payment Authorizaiton Canceled")
+    println("PayPal Future Payment Authorization Canceled")
     successView.hidden = true
     futurePaymentViewController?.dismissViewControllerAnimated(true, completion: nil)
   }


### PR DESCRIPTION
```Authorization``` instead of ```Authorizaiton```